### PR TITLE
#15: temporarily disable the Shapefile export option until the No Space error is fixed

### DIFF
--- a/access_frontend/src/Components/Sections/OutputFormatSection.tsx
+++ b/access_frontend/src/Components/Sections/OutputFormatSection.tsx
@@ -42,11 +42,13 @@ const OutputFormatSectionComponent: React.FC<SectionComponentSpec> = ({
             control={<Radio />}
             label="GeoJson"
           />
-          <FormControlLabel
+          {
+          // #15: disable the Shapefile export until the 'No Space' issue is resolved
+          /* <FormControlLabel
             value="ShapeFile"
             control={<Radio />}
             label="Shapefile"
-          />
+          /> */}
           <FormControlLabel value="CSV" control={<Radio />} label="CSV" />
         </RadioGroup>
       </FormControl>


### PR DESCRIPTION
This PR addresses part of issue #15. 

The "Shapefile" export option will be temporarily hidden until the UI problem for Advanced Metrics is fixed. I'll then revisit this issue and fix the "No Space" error for shapefiles. Once fixed, I'll enable the "Shapefile" export button again.