### PR TITLE
Added instruction messages for users who need to re-upload the file

### DIFF
--- a/access_frontend/src/Components/Sections/DestinationFileUploadSection.tsx
+++ b/access_frontend/src/Components/Sections/DestinationFileUploadSection.tsx
@@ -340,7 +340,13 @@ const DestinationFileUploadComponent: React.FC<SectionComponentSpec> = ({
 		</Stack>
 	);
 };
-
+const AdditionalDescription: React.FC<{job:Job}> = ({job}) => {
+    return (
+        <Typography>
+            If you select the wrong file or need to change the columns, please <b>refresh this page</b> and start from the beginning.
+        </Typography>
+    )
+}
 const canProgress = (job: Job) =>
 	!!job.destinationFile &&
 	!!(
@@ -360,6 +366,7 @@ const tooltip = (_job: Job) =>
 
 const DestinationFileUploadSection = {
 	component: DestinationFileUploadComponent,
+	additionalDescription: AdditionalDescription,
 	canProgress,
 	shouldShow,
 	prompt,


### PR DESCRIPTION
As an enhancement, add the helper message for users who upload the wrong file or select the wrong columns:
<img width="646" alt="Screenshot 2024-05-20 at 2 02 16 PM" src="https://github.com/healthyregions/access_app/assets/92752107/87da321c-ece2-4521-9d1b-8b6923c4c371">
